### PR TITLE
Thread safety for Portenta platform

### DIFF
--- a/src/EasyLogger.h
+++ b/src/EasyLogger.h
@@ -2,6 +2,16 @@
 #define _EASYLOGGGER_h
     #include <Arduino.h>
 
+    #ifdef ARDUINO_PORTENTA_H7_M7
+        #include <mbed.h>
+        static rtos::Mutex log_serial_mutex;
+        #define LOG_MUTEX_LOCK log_serial_mutex.lock();
+        #define LOG_MUTEX_UNLOCK log_serial_mutex.unlock();
+    #else
+        #define LOG_MUTEX_LOCK
+        #define LOG_MUTEX_UNLOCK
+    #endif
+
     // Streaming operator for serial print use to make nice logging like
     // LOG_DEBUG("TST", "var1" << var1 << ", var2=" << var2)
     template <class T>
@@ -101,21 +111,25 @@
        It will log time-stamp and log-content with an endline */
     #define LOG_RAW_FILTER_LINE(loglevel, svc, content)     \
     {                                                       \
+        LOG_MUTEX_LOCK;                                     \
         if (should_log_line(svc))                           \
         {                                                   \
             print_log_line_header(loglevel, svc);           \
             LOG_OUTPUT << content;                          \
             LOG_OUTPUT << endl;                             \
         }                                                   \
+        LOG_MUTEX_UNLOCK;                                   \
     }
 
     /* Reusable code for each loglevel macro funcion. This code is inserted in the log-statement
        if filtering is disabled. Just prints a time-stamp and the log content with an endline */
     #define LOG_RAW_LINE(loglevel, svc, content)            \
     {                                                       \
+        LOG_MUTEX_LOCK;                                     \
         print_log_line_header(loglevel, svc);               \
         LOG_OUTPUT << content;                              \
         LOG_OUTPUT << endl;                                 \
+        LOG_MUTEX_UNLOCK;                                   \
     }
 
     /* If the log statement function shouldn't be compiled in, because our loglevel is too low .


### PR DESCRIPTION
Some Arduino platforms are multi-threaded. Debugging multi-threaded sketches requires the logging infrastructure to be thread safe.

This PR adds thread safety specifically for the ARDUINO_PORTENTA_H7_M7 platform using the MbedOS `rtos::Mutex` to guard the Serial object. MbedOS is part of the Arduino Core for Portenta.

Without mutex (mangled output):
```
000099133  DEBUG     [update] : Speed: 1999.00 rpm<CR><LF>
000099148  DEBUG     [update000099153  INFO     ] : Speed:  [1999control.] : 0T = 026.3 rpm1<CR><LF>
 C<CR><LF>
000099155  INFO      [control] : loop time: max 25 ms, min 20 ms<CR><LF>
000099165  DEBUG     [update] : Speed: 2013.00 rpm<CR><LF>
```

With mutex (clean output):
```
000020388  DEBUG     [update] : Speed: 1980.00 rpm<CR><LF>
000020397  INFO      [control] : T = 27.26 C<CR><LF>
000020398  INFO      [control] : loop time: max 25 ms, min 20 ms<CR><LF>
000020398  DEBUG     [update] : Speed: 1980.00 rpm<CR><LF>
```

Thanks for creating and maintaining this great library!
Would be nice if this change finds its way upstream.